### PR TITLE
tools/genxml: fix -Wincompatible-pointer-types

### DIFF
--- a/tools/genxml.c
+++ b/tools/genxml.c
@@ -557,7 +557,7 @@ char * iio_context_create_xml(const struct iio_context *ctx)
 	size_t *devices_len = NULL;
 	char *str, *ptr, *eptr, **devices = NULL;
 	char ** ctx_attrs, **ctx_values;
-	char *ctx_attr, *ctx_value;
+	const char *ctx_attr, *ctx_value;
 	unsigned int i;
 
 	len = sizeof(xml_header) - 1;


### PR DESCRIPTION
This fixes the following warnings:

    /home/ubuntu/bl/iio-emu/tools/genxml.c: In function ‘iio_context_create_xml’:
    /home/ubuntu/bl/iio-emu/tools/genxml.c:585:46: warning: passing argument 3 of ‘iio_context_get_attr’ from incompatible pointer type [-Wincompatible-pointer-types]
    585 |                 iio_context_get_attr(ctx, i, &ctx_attr, &ctx_value);
        |                                              ^~~~~~~~~
        |                                              |
        |                                              char **
    In file included from /home/ubuntu/bl/iio-emu/tools/genxml.c:20:
    /usr/include/iio.h:501:30: note: expected ‘const char **’ but argument is of type ‘char **’
    501 |                 const char **name, const char **value);
        |                 ~~~~~~~~~~~~~^~~~
    /home/ubuntu/bl/iio-emu/tools/genxml.c:585:57: warning: passing argument 4 of ‘iio_context_get_attr’ from incompatible pointer type [-Wincompatible-pointer-types]
    585 |                 iio_context_get_attr(ctx, i, &ctx_attr, &ctx_value);
        |                                                         ^~~~~~~~~~
        |                                                         |
        |                                                         char **
    In file included from /home/ubuntu/bl/iio-emu/tools/genxml.c:20:
    /usr/include/iio.h:501:49: note: expected ‘const char **’ but argument is of type ‘char **’
    501 |                 const char **name, const char **value);
        |                                    ~~~~~~~~~~~~~^~~~~