### PR TITLE
tools/genxml: fix print format warning

### DIFF
--- a/tools/genxml.c
+++ b/tools/genxml.c
@@ -704,6 +704,6 @@ int main(int argc, const char *argv[])
 	}
 
 	const char *xml = iio_context_create_xml(context);
-	printf(xml);
+	printf("%s", xml);
 	return 0;
 }


### PR DESCRIPTION
This fixes the following warning:

    /home/ubuntu/bl/iio-emu/tools/genxml.c: In function ‘main’:
    /home/ubuntu/bl/iio-emu/tools/genxml.c:707:9: warning: format not a string literal and no format arguments [-Wformat-security]
    707 |         printf(xml);
        |         ^~~~~~