### PR TITLE
Enable use of custom ports

### DIFF
--- a/iiod/ops/abstract_ops.hpp
+++ b/iiod/ops/abstract_ops.hpp
@@ -59,6 +59,7 @@ public:
 
 	virtual void setCurrentSocket(AbstractSocket* socket) = 0;
 	virtual void socketDisconnected(int fd) = 0;
+	uint16_t port = 0;
 
 	// tinyiiod ops:
 	// communication

--- a/networking/tcp_server.cpp
+++ b/networking/tcp_server.cpp
@@ -60,7 +60,6 @@ extern "C"
 #include <tinyiiod/tinyiiod.h>
 }
 
-constexpr int PORT = 30431;
 constexpr int BACKLOG = 64;
 
 bool running = true;
@@ -76,6 +75,7 @@ TcpServer::TcpServer(const char* type, std::vector<const char*>& args)
 		exit(1);
 	}
 	m_iiod = tinyiiod_create(m_ops->getIIODOps());
+	port = m_ops->port;
 }
 
 TcpServer::~TcpServer()
@@ -120,7 +120,7 @@ bool TcpServer::start()
 		return false;
 	}
 
-	ret = networkInterface->bind(PORT);
+	ret = networkInterface->bind(static_cast<uint16_t> (port));
 	if (ret < 0) {
 		Logger::log(IIO_EMU_FATAL, {"Bind failed: ", strerror(errno)});
 		delete networkInterface;

--- a/networking/tcp_server.hpp
+++ b/networking/tcp_server.hpp
@@ -56,6 +56,8 @@ public:
 
 	bool start();
 
+	int port = 30431;
+
 private:
 	static void stop(int signum);
 


### PR DESCRIPTION
PR add use of custom ports for contexts. This is handy if you want to do parallel testing and have a few iio-emu's running.