### PR TITLE
dev: add option to add TCP port when starting the emulator

### DIFF
--- a/networking/tcp_server.cpp
+++ b/networking/tcp_server.cpp
@@ -60,7 +60,7 @@ extern "C"
 #include <tinyiiod/tinyiiod.h>
 }
 
-constexpr int PORT = 30431;
+
 constexpr int BACKLOG = 64;
 
 bool running = true;
@@ -87,7 +87,7 @@ TcpServer::~TcpServer()
 	delete m_ops;
 }
 
-bool TcpServer::start()
+bool TcpServer::start(uint16_t port)
 {
 	int ret;
 	bool errorOccured = false;
@@ -120,7 +120,7 @@ bool TcpServer::start()
 		return false;
 	}
 
-	ret = networkInterface->bind(PORT);
+	ret = networkInterface->bind(port);
 	if (ret < 0) {
 		Logger::log(IIO_EMU_FATAL, {"Bind failed: ", strerror(errno)});
 		delete networkInterface;

--- a/networking/tcp_server.hpp
+++ b/networking/tcp_server.hpp
@@ -41,6 +41,7 @@
 #define IIO_EMU_TCP_SERVER_H
 
 #include <vector>
+#include <stdint.h>
 
 struct tinyiiod;
 
@@ -54,7 +55,7 @@ public:
 	TcpServer(const char* type, std::vector<const char*>& args);
 	~TcpServer();
 
-	bool start();
+	bool start(uint16_t port);
 
 private:
 	static void stop(int signum);


### PR DESCRIPTION
Allows user to mention what TCP port they want to use when starting the emulator
Enables us to run multiple emulators 