### PR TITLE
build: allow building gen_xml standalone

### DIFF
--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -41,6 +41,8 @@ project(iio-emu_gen_xml LANGUAGES C)
 find_library(IIO_LIBRARIES NAMES iio libiio)
 find_path(IIO_INCLUDE_DIRS iio.h)
 
+find_package(LibXml2 REQUIRED)
+
 add_executable(${PROJECT_NAME}
 	genxml.c)
 

--- a/tools/genxml.c
+++ b/tools/genxml.c
@@ -109,7 +109,7 @@ static const char xml_header[] = "<?xml version=\"1.0\" encoding=\"utf-8\"?>"
 				 "<!ATTLIST debug-attribute name CDATA #REQUIRED value CDATA #IMPLIED>"
 				 "<!ATTLIST buffer-attribute name CDATA #REQUIRED value CDATA #IMPLIED>"
 				 "]>";
-#define BUF_SIZE 100
+#define BUF_SIZE NAME_MAX
 
 static char *get_attr_xml2(const struct iio_device *device, const char *attr, size_t *length, enum iio_attr_type type)
 {


### PR DESCRIPTION
The CMakeLists.txt in the tools subdir is written as an independent project list file.

However, it failed to build as-is because the dependency to libxml2 was actually inherited by the root list file.

Simply find the libxml2 dep explicitely in this list file to fix it.