### PR TITLE
generic: add iio_emu attribute to context it retunrs version of iio-emu

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -50,6 +50,8 @@ set(IIO_EMU_VERSION_MINOR 2)
 set(IIO_EMU_VERSION_PATCH 0)
 set(IIO_EMU_VERSION ${IIO_EMU_VERSION_MAJOR}.${IIO_EMU_VERSION_MINOR}.${IIO_EMU_VERSION_PATCH})
 
+
+configure_file(utils/version_config.h.cmakein ${CMAKE_CURRENT_BINARY_DIR}/version_config.h @ONLY)
 configure_file(iio-emu.iss.cmakein ${CMAKE_CURRENT_BINARY_DIR}/iio-emu.iss @ONLY)
 
 option(BUILD_TOOLS "Build the tools" OFF)
@@ -102,6 +104,7 @@ target_include_directories(${PROJECT_NAME}
         ${CMAKE_CURRENT_SOURCE_DIR}
         ${LIBXML2_INCLUDE_DIR}
         ${CMAKE_CURRENT_BINARY_DIR}/resources
+        ${CMAKE_BINARY_DIR}
         )
 
 if (WIN32 OR CYGWIN OR MINGW)

--- a/iiod/context/generic_xml/generic_xml_context.cpp
+++ b/iiod/context/generic_xml/generic_xml_context.cpp
@@ -48,12 +48,29 @@
 #include "utils/input_parser.hpp"
 #include "utils/network_ops.hpp"
 #include "utils/utility.hpp"
+#include "version_config.h"
 
 #include <iiod/context/generic_xml/devices/generic_rx_device.hpp>
 #include <iiod/context/generic_xml/devices/generic_tx_device.hpp>
 #include <libxml/tree.h>
 
 using namespace iio_emu;
+
+static void addVersionContextAttribute(xmlDoc* doc)
+{
+	if (!doc) return;
+
+	xmlNode* root = xmlDocGetRootElement(doc);
+	if (!root) return;
+
+	// Create the iio_emu context-attribute node with actual version value
+	xmlNode* versionAttr = xmlNewNode(nullptr, reinterpret_cast<const xmlChar*>("context-attribute"));
+	xmlSetProp(versionAttr, reinterpret_cast<const xmlChar*>("name"), reinterpret_cast<const xmlChar*>("iio_emu"));
+	xmlSetProp(versionAttr, reinterpret_cast<const xmlChar*>("value"), reinterpret_cast<const xmlChar*>(IIO_EMU_VERSION));
+
+	// Add it as the first child of the root context element
+	xmlAddChild(root, versionAttr);
+}
 
 GenericXmlContext::GenericXmlContext(std::vector<const char*>& args)
 {
@@ -62,6 +79,10 @@ GenericXmlContext::GenericXmlContext(std::vector<const char*>& args)
 
 	// TODO: check xmlPath
 	m_doc = xmlReadFile(xmlPath, nullptr, XML_PARSE_DTDVALID);
+
+	// Add the iio_emu:VERSION context attribute to the loaded XML
+	addVersionContextAttribute(m_doc);
+
 	m_xml_size = iio_emu::getXml(m_doc, &m_ctx_xml);
 
 	for (const auto& devInfo : devices) {
@@ -82,6 +103,10 @@ GenericXmlContext::GenericXmlContext(std::vector<const char*>& args)
 GenericXmlContext::GenericXmlContext(const char* file, int fileSize)
 {
 	m_doc = xmlReadMemory(file, fileSize, nullptr, nullptr, XML_PARSE_DTDVALID);
+
+	// Add the iio_emu:VERSION context attribute to the loaded XML
+	addVersionContextAttribute(m_doc);
+
 	m_xml_size = iio_emu::getXml(m_doc, &m_ctx_xml);
 }
 

--- a/utils/attr_ops_xml.cpp
+++ b/utils/attr_ops_xml.cpp
@@ -40,12 +40,14 @@
 #include "attr_ops_xml.hpp"
 
 #include "xml_utils.hpp"
+#include "version_config.h"
 
 #include <libxml/tree.h>
 
 ssize_t iio_emu::read_device_attr(struct _xmlDoc* doc, const char* device_id, const char* attr, char* buf, size_t len,
 				  enum iio_attr_type type)
 {
+
 	xmlNode* node_attr;
 	char* value;
 	LIBXML_TEST_VERSION;
@@ -129,6 +131,15 @@ ssize_t iio_emu::write_channel_attr(struct _xmlDoc* doc, const char* device_id, 
 
 ssize_t iio_emu::read_context_attr(struct _xmlDoc* doc, const char* attr, char* buf, size_t len)
 {
+	// Handle special iio_emu context attribute
+	if (attr && strcmp(attr, "iio_emu") == 0) {
+		const char* version = IIO_EMU_VERSION;
+		size_t version_len = strlen(version);
+		if (version_len >= len) return -ENOENT;
+		strcpy(buf, version);
+		return static_cast<ssize_t>(version_len);
+	}
+
 	xmlNode* node_attr;
 	char* value;
 

--- a/utils/version_config.h.cmakein
+++ b/utils/version_config.h.cmakein
@@ -1,0 +1,6 @@
+#ifndef VERSION_CONFIG_H
+#define VERSION_CONFIG_H
+
+#define IIO_EMU_VERSION "@IIO_EMU_VERSION@"
+
+#endif // VERSION_CONFIG_H


### PR DESCRIPTION
This attribute is helpful for applications that have functionalities that require hardware enabling the users to filter between the emu devices and hardware devices. 

Also being able to check version of iio-emu might help in the future,